### PR TITLE
Fixed an issue that caused the home button of the device to lose vibration feedback under certain circumstances.

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -8,10 +8,12 @@ BOOL enabled, wantsHomeBarSB, wantsHomeBarLS, wantsKeyboardDock, wantsRoundedApp
 BOOL disableGestures = NO, wantsGesturesDisabledWhenKeyboard, wantsCCGrabber, wantsPIP, wantsProudLock, wantsHideSBCC,wantsLSShortcuts, wantsBatteryPercent, wantsiPadDock;
 BOOL wantsDeviceSpoofing, wantsCompatabilityMode, wantsiPadMultitasking;
 
+%group enabled
 %hook BSPlatform
 - (NSInteger)homeButtonType {
 	return 2;
 }
+%end
 %end
 
 %group ForceDefaultKeyboard
@@ -663,6 +665,8 @@ void loadPrefs() {
             bool const isSpringBoard = [@"SpringBoard" isEqualToString:[NSProcessInfo processInfo].processName];
 
             if (isSpringBoard) {
+
+                %init(enabled);
 
                 if (statusBarStyle == 1) %init(StatusBariPad)      
                 else if (statusBarStyle == 2) %init(StatusBarX);


### PR DESCRIPTION
If the user is using substitute (mainly  from unc0ver, the substitute from chimera has not been tested), in some cases Little11 may conflict with other tweaks and cause home button vibration feedback to fail. The cause of this problem has not been determined, this may be a bug in the substitute. Injecting hook of BSPlatform to springboard instead of UIKit can solve this problem.